### PR TITLE
MS-2872 add new callback in livox sdk2 for handling error states

### DIFF
--- a/include/livox_lidar_api.h
+++ b/include/livox_lidar_api.h
@@ -103,6 +103,13 @@ void SetLivoxLidarImuDataCallback(LivoxLidarImuDataCallback cb, void* client_dat
 void SetLivoxLidarInfoCallback(LivoxLidarInfoCallback cb, void* client_data);
 
 /**
+ * Set the callback to receive direct LIDAR Status Info.
+ * @param cb                     callback to receive Status Info.
+ * @param client_data            user data associated with the command.
+ */
+void SetLivoxDirectLidarStateInfoCallback(LivoxDirectLidarStateInfoCallback cb, void* client_data);
+
+/**
  * DisableLivoxLidar console log output.
  */
 void DisableLivoxSdkConsoleLogger();

--- a/include/livox_lidar_def.h
+++ b/include/livox_lidar_def.h
@@ -519,6 +519,13 @@ typedef void (*LivoxLidarImuDataCallback)(const uint32_t handle, const uint8_t d
 typedef void(*LivoxLidarInfoCallback)(const uint32_t handle, const uint8_t dev_type, const char* info, void* client_data);
 
 /**
+ * Callback function for receiving direct LIDAR Status Info.
+ * @param direct_info            direct status info.
+ * @param client_data            user data associated with the command.
+ */
+typedef void(*LivoxDirectLidarStateInfoCallback)(const uint32_t handle, const uint8_t dev_type, const DirectLidarStateInfo &direct_info, void* client_data);
+
+/**
  * Callback function for receiving Status Info.
  * @param status                 status info.
  * @param client_data            user data associated with the command.

--- a/sdk_core/CMakeLists.txt
+++ b/sdk_core/CMakeLists.txt
@@ -73,6 +73,7 @@ set(MICROSTAR_GDB_COMPILE_OPTIONS
         -g3
         )
 
+# cmake .. -DMICROSTAR_DEBUG_GDB=1 to enable gdb debug symbols        
 if(${MICROSTAR_DEBUG_GDB})
         message(WARNING "[Livox-SDK2]Enable GDB debug symbols")
         target_compile_options(${SDK_LIBRARY_STATIC}
@@ -100,6 +101,7 @@ set(MICROSTAR_MEMCHECK_COMPILE_OPTIONS
         -fsanitize=vptr,builtin
         )
 
+# cmake .. -DMICROSTAR_DEBUG_MEMCHECK=1 to enable memcheck
 if(${MICROSTAR_DEBUG_MEMCHECK})
 # the memory check options must be enabled for all translation units including the downstream projects
 # so make them public

--- a/sdk_core/command_handler/general_command_handler.cpp
+++ b/sdk_core/command_handler/general_command_handler.cpp
@@ -554,6 +554,18 @@ void GeneralCommandHandler::PushLivoxLidarInfo(const uint32_t handle, const std:
   }
 }
 
+void GeneralCommandHandler::PushLivoxDirectLidarStateInfo(const uint32_t handle, const DirectLidarStateInfo &info)
+{
+  std::lock_guard<std::mutex> lock(dev_type_mutex_);
+  if (device_dev_type_.find(handle) != device_dev_type_.end()) {
+    uint8_t dev_type = device_dev_type_[handle];
+
+    if (livox_direct_lidar_state_info_cb_) {
+      livox_direct_lidar_state_info_cb_(handle, dev_type, info, livox_direct_lidar_state_info_client_data_);
+    }
+  }
+}
+
 std::shared_ptr<CommandHandler> GeneralCommandHandler::GetLidarCommandHandler(const uint32_t handle) {
   std::lock_guard<std::mutex> lock(dev_type_mutex_);
   if (device_dev_type_.find(handle) != device_dev_type_.end()) {

--- a/sdk_core/command_handler/general_command_handler.h
+++ b/sdk_core/command_handler/general_command_handler.h
@@ -100,6 +100,11 @@ class GeneralCommandHandler : public noncopyable {
     livox_lidar_info_client_data_ = client_data;
   }
 
+  void SetLivoxDirectLidarStateInfoCallback(LivoxDirectLidarStateInfoCallback cb, void* client_data) {
+    livox_direct_lidar_state_info_cb_ = cb;
+    livox_direct_lidar_state_info_client_data_ = client_data;
+  }
+
   void LivoxLidarAddCmdObserver(LivoxLidarCmdObserverCallBack cb, void* client_data) {
     cmd_observer_cb_ = cb;
     cmd_observer_client_data_ = client_data;
@@ -114,6 +119,7 @@ class GeneralCommandHandler : public noncopyable {
   void UpdateLidarCfg(const uint8_t dev_type, const uint32_t handle, const uint16_t lidar_cmd_port);
   void LivoxLidarInfoChange(const uint32_t handle);
   void PushLivoxLidarInfo(const uint32_t handle, const std::string& info);
+  void PushLivoxDirectLidarStateInfo(const uint32_t handle, const DirectLidarStateInfo &info);
   bool GetQueryLidarInternalInfoKeys(const uint32_t handle, std::set<ParamKeyName>& key_sets);
   const LivoxLidarCfg& GetLidarCfg(const uint32_t handle);
   livox_status LivoxLidarRequestReset(uint32_t handle, LivoxLidarResetCallback cb, void* client_data);
@@ -149,6 +155,9 @@ class GeneralCommandHandler : public noncopyable {
 
   LivoxLidarInfoCallback livox_lidar_info_cb_;
   void* livox_lidar_info_client_data_;
+
+  LivoxDirectLidarStateInfoCallback livox_direct_lidar_state_info_cb_;
+  void* livox_direct_lidar_state_info_client_data_;
 
   LivoxLidarCmdObserverCallBack cmd_observer_cb_{nullptr};
   void* cmd_observer_client_data_{nullptr};

--- a/sdk_core/command_handler/hap_command_handler.cpp
+++ b/sdk_core/command_handler/hap_command_handler.cpp
@@ -84,9 +84,11 @@ void HapCommandHandler::OnCommandAck(uint32_t handle, const Command &command) {
 
 void HapCommandHandler::OnCommandCmd(const uint32_t handle, uint16_t lidar_port, const Command& command) {
   if (command.packet.cmd_id == kCommandIDLidarPushMsg && lidar_port == kHAPPushMsgPort) {
-    std::string info;
-    ParseLidarStateInfo::Parse(command.packet, info);
-    GeneralCommandHandler::GetInstance().PushLivoxLidarInfo(handle, info);
+    std::string info_str;
+    DirectLidarStateInfo state_info;
+    ParseLidarStateInfo::Parse(command.packet, state_info, info_str);
+    GeneralCommandHandler::GetInstance().PushLivoxDirectLidarStateInfo(handle, state_info);
+    GeneralCommandHandler::GetInstance().PushLivoxLidarInfo(handle, info_str);
   }
 }
 

--- a/sdk_core/command_handler/mid360_command_handler.cpp
+++ b/sdk_core/command_handler/mid360_command_handler.cpp
@@ -84,9 +84,11 @@ void Mid360CommandHandler::OnCommandAck(uint32_t handle, const Command &command)
 
 void Mid360CommandHandler::OnCommandCmd(uint32_t handle, const uint16_t lidar_port, const Command &command) {
   if (command.packet.cmd_id == kCommandIDLidarPushMsg && lidar_port == kMid360LidarPushMsgPort) {
-    std::string info; 
-    ParseLidarStateInfo::Parse(command.packet, info);
-    GeneralCommandHandler::GetInstance().PushLivoxLidarInfo(handle, info);
+    std::string info_str;
+    DirectLidarStateInfo state_info;
+    ParseLidarStateInfo::Parse(command.packet, state_info, info_str);
+    GeneralCommandHandler::GetInstance().PushLivoxDirectLidarStateInfo(handle, state_info);
+    GeneralCommandHandler::GetInstance().PushLivoxLidarInfo(handle, info_str);
   }
 }
 

--- a/sdk_core/command_handler/parse_lidar_state_info.cpp
+++ b/sdk_core/command_handler/parse_lidar_state_info.cpp
@@ -21,6 +21,18 @@ bool ParseLidarStateInfo::Parse(const CommPacket& packet, std::string& info_str)
   return true;
 }
 
+bool ParseLidarStateInfo::Parse(const CommPacket& packet, DirectLidarStateInfo& info, std::string& info_str)
+{
+  std::set<ParamKeyName> key_mask;
+  
+  if (!ParseStateInfo(packet, info, key_mask)) {
+    return false;
+  }
+
+  LivoxLidarStateInfoToJson(info, key_mask, info_str);
+  return true;
+}
+
 bool ParseLidarStateInfo::ParseStateInfo(const CommPacket& packet,
                                          DirectLidarStateInfo& info,
                                          std::set<ParamKeyName>& key_mask) {  

--- a/sdk_core/command_handler/parse_lidar_state_info.h
+++ b/sdk_core/command_handler/parse_lidar_state_info.h
@@ -47,6 +47,7 @@ namespace lidar {
 class ParseLidarStateInfo {
  public:
   static bool Parse(const CommPacket& packet, std::string& info);
+  static bool Parse(const CommPacket& packet, DirectLidarStateInfo& info, std::string& info_str);
  private:
   static bool ParseStateInfo(const CommPacket& packet, DirectLidarStateInfo& info, std::set<ParamKeyName>& key_mask);
   static void ParseLidarIpAddr(const CommPacket& packet, uint16_t off, DirectLidarStateInfo& info);

--- a/sdk_core/livox_lidar_sdk.cpp
+++ b/sdk_core/livox_lidar_sdk.cpp
@@ -163,6 +163,10 @@ void SetLivoxLidarInfoCallback(LivoxLidarInfoCallback cb, void* client_data) {
   GeneralCommandHandler::GetInstance().SetLivoxLidarInfoCallback(cb, client_data);
 }
 
+void SetLivoxDirectLidarStateInfoCallback(LivoxDirectLidarStateInfoCallback cb, void* client_data) {
+  GeneralCommandHandler::GetInstance().SetLivoxDirectLidarStateInfoCallback(cb, client_data);
+}
+
 void SetLivoxLidarInfoChangeCallback(LivoxLidarInfoChangeCallback cb, void* client_data) {
   GeneralCommandHandler::GetInstance().SetLivoxLidarInfoChangeCallback(cb, client_data);
 }


### PR DESCRIPTION
Add a callback to retrieve DirectLidarStateInfo which contains the current work state of the lidar and the hms code.

https://livox-wiki-en.readthedocs.io/en/latest/tutorials/new_product/mid360/hms_code_mid360.html